### PR TITLE
some fixes and enhancements

### DIFF
--- a/radio
+++ b/radio
@@ -241,7 +241,7 @@ case $1 in
 		exec "$sqlite" "$db" "$get_most_played"
 	;;
 	-u|--update)
-		location="$(which "$0")"
+		location="$(command -v "$0")"
 		[[ "$location" == "" ]] && die "Location of Script could not be identified, please include it in your PATH variable"
 		echo "Updating radio Script at $location... "
 		echo

--- a/radio
+++ b/radio
@@ -381,8 +381,9 @@ echo
 [ -z "$proxy" ] || url="${proxy}/$url"
 if [[ $dumptime > 0 ]]; then
 	mplayer -dumpstream "$url" & 
+	MPLAYER_PID=$!
 	sleep "$dumptime"m
-	killall mplayer
+	kill $MPLAYER_PID
 else
 	mplayer -quiet "$url" 2>&1 | sed -nu "s/^ICY.*StreamTitle='\([^;]*\)';.*/\1/p"
 fi

--- a/radio
+++ b/radio
@@ -29,15 +29,15 @@ function addinteractive() {
 	echo "Interactive Mode for adding a station"
 	echo
 	echo -n "Station name: "
-	read name
+	read -r name
 	echo -n "Streaming URL: "
-	read url1
+	read -r url1
 	echo -n "(Optional) Backup-Streaming URL (Just press enter to skip): "
-	read url2
+	read -r url2
 	echo -n "Location of the station: "
-	read loc
+	read -r loc
 	echo -n "Tags for the station (e.g.: 80s, news, chillout): "
-	read tags
+	read -r tags
 	
 	#restart script with the parameters
 	bash "$0" "-a" "$name" "$url1" "$url2" "$loc" "$tags" && exit 0
@@ -379,7 +379,7 @@ echo
 
 
 [ -z "$proxy" ] || url="${proxy}/$url"
-if [[ $dumptime > 0 ]]; then
+if [[ $dumptime -gt 0 ]]; then
 	mplayer -dumpstream "$url" & 
 	MPLAYER_PID=$!
 	sleep "$dumptime"m


### PR DESCRIPTION
two fixes:
* kill just the recording mplayer process install of all when dumping finnishes
* the comparison whether dumptime is greater 0 should use the numerical -gt instead of >

two minor improvements according to shellcheck:
* use read -r
* use command -v instead of which. which ist not standard.